### PR TITLE
Change to support a request that has a request body rather than request parameters

### DIFF
--- a/inproctester-htmlunit/src/main/java/com/thoughtworks/inproctester/htmlunit/HtmlUnitInprocRequest.java
+++ b/inproctester-htmlunit/src/main/java/com/thoughtworks/inproctester/htmlunit/HtmlUnitInprocRequest.java
@@ -37,7 +37,12 @@ class HtmlUnitInProcRequest implements InProcRequest {
 
     @Override
     public String getContent() {
-        return new UrlEncodedContent(request.getRequestParameters()).generateFormDataAsString();
+        if (request.getRequestParameters().size() > 0) {
+            return new UrlEncodedContent(request.getRequestParameters()).generateFormDataAsString();
+        } else if(request.getRequestBody().length() > 0) {
+            return request.getRequestBody();
+        }
+        return "";
     }
 
     @Override


### PR DESCRIPTION
Hi Alex.  On our project we needed to be able to support AJAX post requests with a request body rather than request parameters.  I made this change to the HtmlUnitInProcRequest that solved our problem so submitting it back to you for review.  Cheers, Rob
