### PR TITLE
Enable GET support for RESTEasy

### DIFF
--- a/inproctester-resteasy-tests/src/test/java/com/thoughtworks/inproctester/resteasy/tests/InProcessResteasyTest.java
+++ b/inproctester-resteasy-tests/src/test/java/com/thoughtworks/inproctester/resteasy/tests/InProcessResteasyTest.java
@@ -52,6 +52,19 @@ public class InProcessResteasyTest {
 //        Assert.assertEquals(testResource, testResourceFromServer);
     }
 
+    @Test
+    public void shouldGetResource() throws Exception {
+        ClientRequest request = new ClientRequest("http://localhost/", new InProcessClientExecutor(httpAppTester));
+        JsonNode testResource = objectMapper.readValue("{\"name\":\"test\"}", JsonNode.class);
+        ClientResponse<JsonNode> response = request.body(MediaType.APPLICATION_JSON, testResource).post(JsonNode.class);
+
+        request = new ClientRequest(response.getLocation().getHref(), new InProcessClientExecutor(httpAppTester));
+        response = request.accept(MediaType.APPLICATION_JSON).get(JsonNode.class);
+
+        Assert.assertEquals(200, response.getStatus());
+        JsonNode entity = response.getEntity();
+        Assert.assertEquals(testResource, entity);
+    }
 
 }
 

--- a/inproctester-resteasy/src/main/java/com/thoughtworks/inproctester/resteasy/RestEasyClientInProcRequest.java
+++ b/inproctester-resteasy/src/main/java/com/thoughtworks/inproctester/resteasy/RestEasyClientInProcRequest.java
@@ -25,7 +25,9 @@ public class RestEasyClientInProcRequest implements InProcRequest {
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
-        headers.put("Content-type", clientRequest.getBodyContentType().toString());
+        if (clientRequest.getBodyContentType() != null) {
+            headers.put("Content-type", clientRequest.getBodyContentType().toString());
+        }
         headers.putAll(asMap(clientRequest.getHeaders()));
     }
 


### PR DESCRIPTION
A request body isn't allowed for GET requests, but RestEasyClientInProcRequest tried to
do a toString() on ClientRequest#getBodyContentType() nonetheless.  NullPointerException
goodness.
