### PR TITLE
Fixing CookieParser dateformat issue and a few code quality rules violations

### DIFF
--- a/inproctester-core/src/main/java/com/thoughtworks/inproctester/core/InProcResponseWrapper.java
+++ b/inproctester-core/src/main/java/com/thoughtworks/inproctester/core/InProcResponseWrapper.java
@@ -17,7 +17,8 @@ package com.thoughtworks.inproctester.core;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.StandardCharsets;
 import java.util.Collection;
-import java.util.Set;
+
+import com.thoughtworks.inproctester.core.exceptions.ContentRetrievalException;
 
 public class InProcResponseWrapper implements InProcResponse {
 
@@ -35,7 +36,7 @@ public class InProcResponseWrapper implements InProcResponse {
         try {
             return new String(getContentBytes(), getCharacterEncoding());
         } catch (UnsupportedEncodingException e) {
-            throw new RuntimeException(e);
+            throw new ContentRetrievalException(e);
         }
     }
 

--- a/inproctester-core/src/main/java/com/thoughtworks/inproctester/core/UrlHelper.java
+++ b/inproctester-core/src/main/java/com/thoughtworks/inproctester/core/UrlHelper.java
@@ -20,8 +20,13 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.URLEncoder;
 
-public class UrlHelper {
+import com.thoughtworks.inproctester.core.exceptions.HostRetrievalException;
+import com.thoughtworks.inproctester.core.exceptions.UrlEncodingException;
 
+public class UrlHelper {
+	private UrlHelper() {
+	}
+	
     public static String getRequestPath(URI uri) {
         String path = uri.getRawPath();
         String query = uri.getRawQuery();
@@ -42,7 +47,7 @@ public class UrlHelper {
             URI uri = absoluteUrl.toURI();
             return getRequestHost(uri);
         } catch (URISyntaxException e) {
-            throw new RuntimeException(e);
+            throw new HostRetrievalException(e);
         }
     }
 
@@ -60,7 +65,7 @@ public class UrlHelper {
         try {
             return URLEncoder.encode(value, "UTF-8");
         } catch (UnsupportedEncodingException e) {
-            throw new RuntimeException(e);
+            throw new UrlEncodingException(e);
         }
     }
 }

--- a/inproctester-core/src/main/java/com/thoughtworks/inproctester/core/exceptions/ContentRetrievalException.java
+++ b/inproctester-core/src/main/java/com/thoughtworks/inproctester/core/exceptions/ContentRetrievalException.java
@@ -1,0 +1,10 @@
+package com.thoughtworks.inproctester.core.exceptions;
+
+public class ContentRetrievalException extends RuntimeException {
+	
+	private static final long serialVersionUID = 8785446378507287253L;
+
+	public ContentRetrievalException(Exception e) {
+		super(e);
+	}
+}

--- a/inproctester-core/src/main/java/com/thoughtworks/inproctester/core/exceptions/HostRetrievalException.java
+++ b/inproctester-core/src/main/java/com/thoughtworks/inproctester/core/exceptions/HostRetrievalException.java
@@ -1,0 +1,10 @@
+package com.thoughtworks.inproctester.core.exceptions;
+
+public class HostRetrievalException extends RuntimeException {
+	
+	private static final long serialVersionUID = -2798433739196715958L;
+
+	public HostRetrievalException(Exception e) {
+		super(e);
+	}
+}

--- a/inproctester-core/src/main/java/com/thoughtworks/inproctester/core/exceptions/UrlEncodingException.java
+++ b/inproctester-core/src/main/java/com/thoughtworks/inproctester/core/exceptions/UrlEncodingException.java
@@ -1,0 +1,10 @@
+package com.thoughtworks.inproctester.core.exceptions;
+
+public class UrlEncodingException extends RuntimeException {
+	
+	private static final long serialVersionUID = -784039882607132947L;
+
+	public UrlEncodingException(Exception e) {
+		super(e);
+	}
+}

--- a/inproctester-htmlunit/pom.xml
+++ b/inproctester-htmlunit/pom.xml
@@ -1,67 +1,86 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <parent>
-        <groupId>com.thoughtworks.inproctester</groupId>
-        <artifactId>inproctester-project</artifactId>
-        <version>1.0.16-SNAPSHOT</version>
-    </parent>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+	<parent>
+		<groupId>com.thoughtworks.inproctester</groupId>
+		<artifactId>inproctester-project</artifactId>
+		<version>1.0.16-SNAPSHOT</version>
+	</parent>
 
-    <modelVersion>4.0.0</modelVersion>
-    <artifactId>inproctester-htmlunit</artifactId>
-    <name>In Process Tester :: HtmlUnit</name>
-    <packaging>jar</packaging>
+	<modelVersion>4.0.0</modelVersion>
+	<artifactId>inproctester-htmlunit</artifactId>
+	<name>In Process Tester :: HtmlUnit</name>
+	<packaging>jar</packaging>
 
-    <dependencies>
+	<dependencies>
 
-      <dependency>
-            <groupId>com.thoughtworks.inproctester</groupId>
-            <artifactId>inproctester-core</artifactId>
-            <version>1.0.16-SNAPSHOT</version>
-        </dependency>
+		<dependency>
+			<groupId>com.thoughtworks.inproctester</groupId>
+			<artifactId>inproctester-core</artifactId>
+			<version>1.0.16-SNAPSHOT</version>
+		</dependency>
 
-        <dependency>
-            <groupId>net.sourceforge.htmlunit</groupId>
-            <artifactId>htmlunit</artifactId>
-            <version>2.13</version>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.eclipse.jetty</groupId>
-                    <artifactId>jetty-websocket</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
+		<dependency>
+			<groupId>net.sourceforge.htmlunit</groupId>
+			<artifactId>htmlunit</artifactId>
+			<version>2.13</version>
+			<exclusions>
+				<exclusion>
+					<groupId>org.eclipse.jetty</groupId>
+					<artifactId>jetty-websocket</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
 
-    </dependencies>
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
-                <version>2.1.2</version>
+		<!-- log4j2 -->
 
-                <executions>
-                    <execution>
-                        <id>attach-sources</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.8</version>
+		<!-- https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-core -->
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-core</artifactId>
+			<version>2.9.1</version>
+		</dependency>
 
-                <executions>
-                    <execution>
-                        <id>attach-javadoc</id>
-                        <goals>
-                            <goal>jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
+		<!-- https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-api -->
+		<dependency>
+			<groupId>org.apache.logging.log4j</groupId>
+			<artifactId>log4j-api</artifactId>
+			<version>2.9.1</version>
+		</dependency>
+
+
+
+	</dependencies>
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-source-plugin</artifactId>
+				<version>2.1.2</version>
+
+				<executions>
+					<execution>
+						<id>attach-sources</id>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-javadoc-plugin</artifactId>
+				<version>2.8</version>
+
+				<executions>
+					<execution>
+						<id>attach-javadoc</id>
+						<goals>
+							<goal>jar</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
 </project>

--- a/inproctester-htmlunit/src/main/java/com/thoughtworks/inproctester/htmlunit/CookieParser.java
+++ b/inproctester-htmlunit/src/main/java/com/thoughtworks/inproctester/htmlunit/CookieParser.java
@@ -20,16 +20,21 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Arrays;
 import java.util.Date;
+import java.util.Locale;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
 
 public class CookieParser {
 
-    private SimpleDateFormat dateFormat = new SimpleDateFormat("EEE, dd-MMM-yyyy HH:mm:ss zzz");
-
+    private SimpleDateFormat dateFormat = new SimpleDateFormat("EEE, dd-MMM-yyyy HH:mm:ss Z", Locale.US);
+    private static final Logger LOGGER = LogManager.getLogger(CookieParser.class.getName());
 
     public Cookie parseCookie(String hostName, String rawCookie) {
         String[] cookieParts = rawCookie.split(";");
         String valuePart = cookieParts[0];
-        int idx = valuePart.indexOf("=");
+        int idx = valuePart.indexOf('=');
         String cookieName = valuePart.substring(0, idx);
         String cookieValue =  valuePart.substring(idx + 1, valuePart.length());
 
@@ -41,6 +46,11 @@ public class CookieParser {
                 try {
                     expiresDate = dateFormat.parse(expiresDateString);
                 } catch (ParseException ignored) {
+                	if (LOGGER.isDebugEnabled()) {
+                		LOGGER.debug("A problem occured while parsing some cookie: ", ignored);
+                	} else {
+                		LOGGER.error("A technical problem occured while parsing some cookies", ignored);
+                	}
                 }
             }
         }

--- a/inproctester-htmlunit/src/main/java/com/thoughtworks/inproctester/htmlunit/HtmlUnitInprocRequest.java
+++ b/inproctester-htmlunit/src/main/java/com/thoughtworks/inproctester/htmlunit/HtmlUnitInprocRequest.java
@@ -3,6 +3,7 @@ package com.thoughtworks.inproctester.htmlunit;
 import com.gargoylesoftware.htmlunit.WebRequest;
 import com.thoughtworks.inproctester.core.InProcRequest;
 import com.thoughtworks.inproctester.core.UrlHelper;
+import com.thoughtworks.inproctester.htmlunit.exceptions.UriRetrievalException;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -31,13 +32,13 @@ class HtmlUnitInProcRequest implements InProcRequest {
         try {
             return request.getUrl().toURI();
         } catch (URISyntaxException e) {
-            throw new RuntimeException(e);
+            throw new UriRetrievalException(e);
         }
     }
 
     @Override
     public String getContent() {
-        if (request.getRequestParameters().size() > 0) {
+        if (request.getRequestParameters().isEmpty()) {
             return new UrlEncodedContent(request.getRequestParameters()).generateFormDataAsString();
         }
         return request.getRequestBody();

--- a/inproctester-htmlunit/src/main/java/com/thoughtworks/inproctester/htmlunit/HttpTesterAdaptor.java
+++ b/inproctester-htmlunit/src/main/java/com/thoughtworks/inproctester/htmlunit/HttpTesterAdaptor.java
@@ -20,13 +20,16 @@ import com.gargoylesoftware.htmlunit.util.NameValuePair;
 import com.thoughtworks.inproctester.core.InProcRequest;
 import com.thoughtworks.inproctester.core.InProcResponse;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
 public class HttpTesterAdaptor {
-    static WebResponseData adaptResponse(InProcResponse inProcResponse) throws IOException {
+	
+	private HttpTesterAdaptor() {
+	}
+	
+    static WebResponseData adaptResponse(InProcResponse inProcResponse) {
         final List<NameValuePair> headers = new ArrayList<>();
         Collection<String> headerNames = inProcResponse.getHeaderNames();
         for (String headerName : headerNames) {

--- a/inproctester-htmlunit/src/main/java/com/thoughtworks/inproctester/htmlunit/InProcessWebConnection.java
+++ b/inproctester-htmlunit/src/main/java/com/thoughtworks/inproctester/htmlunit/InProcessWebConnection.java
@@ -45,7 +45,7 @@ public class InProcessWebConnection implements WebConnection {
         return new WebResponse(adaptResponse(processTesterRequest(adaptRequest(webRequest))), webRequest, 0);
     }
 
-    private InProcResponse processTesterRequest(InProcRequest inProcRequest) throws IOException {
+    private InProcResponse processTesterRequest(InProcRequest inProcRequest) {
         addCookiesToRequest(inProcRequest);
         InProcResponse inProcResponse = inProcConnection.getResponses(inProcRequest);
         storeCookiesFromResponse(inProcRequest, inProcResponse);

--- a/inproctester-htmlunit/src/main/java/com/thoughtworks/inproctester/htmlunit/exceptions/UriRetrievalException.java
+++ b/inproctester-htmlunit/src/main/java/com/thoughtworks/inproctester/htmlunit/exceptions/UriRetrievalException.java
@@ -1,0 +1,10 @@
+package com.thoughtworks.inproctester.htmlunit.exceptions;
+
+public class UriRetrievalException extends RuntimeException {
+	
+	private static final long serialVersionUID = 6880840561805978802L;
+
+	public UriRetrievalException(Exception e) {
+		super(e);
+	}
+}

--- a/inproctester-htmlunit/src/main/resources/log4j2.xml
+++ b/inproctester-htmlunit/src/main/resources/log4j2.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="WARN">
+  <Appenders>
+    <Console name="Console" target="SYSTEM_OUT">
+      <PatternLayout pattern="%d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n"/>
+    </Console>
+  </Appenders>
+  <Loggers>
+  	<Logger name=" com.thoughtworks.inproctester.htmlunit" level="${env:LOGGING-LEVEL:-WARN}" additivity="true" >
+  		<appender-ref ref="Console" level="${env:LOGGING-LEVEL:-WARN}"/>
+  	</Logger>
+  	
+    <Root level="error">
+      <AppenderRef ref="Console"/>
+    </Root>
+  </Loggers>
+</Configuration>

--- a/inproctester-jersey-tests/src/main/java/com/thoughtworks/inproctester/jersey/testapp/TestApplication.java
+++ b/inproctester-jersey-tests/src/main/java/com/thoughtworks/inproctester/jersey/testapp/TestApplication.java
@@ -28,7 +28,7 @@ import java.util.Map;
 @Singleton
 public class TestApplication {
 
-    private Map<Integer, TestResource> resources = new HashMap<Integer, TestResource>();
+    private Map<Integer, TestResource> resources = new HashMap<>();
 
     @Context
     private UriInfo uriInfo;

--- a/inproctester-jersey-tests/src/main/java/com/thoughtworks/inproctester/jersey/testapp/validation/ValidatingHttpRequest.java
+++ b/inproctester-jersey-tests/src/main/java/com/thoughtworks/inproctester/jersey/testapp/validation/ValidatingHttpRequest.java
@@ -1,0 +1,19 @@
+package com.thoughtworks.inproctester.jersey.testapp.validation;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
+import javax.servlet.http.HttpServletResponse;
+
+public class ValidatingHttpRequest extends HttpServletRequestWrapper {
+
+	public ValidatingHttpRequest(HttpServletRequest request) {
+		super(request);
+	}
+	
+	@Override
+	public boolean authenticate(HttpServletResponse response) {
+		// Customize this
+		return true;
+	}
+
+}

--- a/inproctester-jersey-tests/src/main/java/com/thoughtworks/inproctester/jersey/testapp/validation/ValidationFilter.java
+++ b/inproctester-jersey-tests/src/main/java/com/thoughtworks/inproctester/jersey/testapp/validation/ValidationFilter.java
@@ -10,7 +10,7 @@ import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletRequest;
 
 public class ValidationFilter implements javax.servlet.Filter {
-	 
+
 	@Override
 	public void destroy() {
 		// Customise this
@@ -19,12 +19,11 @@ public class ValidationFilter implements javax.servlet.Filter {
 	@Override
 	public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
 			throws IOException, ServletException {
-		chain.doFilter(new ValidatingHttpRequest( (HttpServletRequest)request ), response);
+		chain.doFilter(new ValidatingHttpRequest((HttpServletRequest) request), response);
 	}
 
 	@Override
 	public void init(FilterConfig arg0) throws ServletException {
-		// TODO Auto-generated method stub
-		
+		// Customize
 	}
-		}
+}

--- a/inproctester-jersey-tests/src/main/java/com/thoughtworks/inproctester/jersey/testapp/validation/ValidationFilter.java
+++ b/inproctester-jersey-tests/src/main/java/com/thoughtworks/inproctester/jersey/testapp/validation/ValidationFilter.java
@@ -1,0 +1,30 @@
+package com.thoughtworks.inproctester.jersey.testapp.validation;
+
+import java.io.IOException;
+
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+
+public class ValidationFilter implements javax.servlet.Filter {
+	 
+	@Override
+	public void destroy() {
+		// Customise this
+	}
+
+	@Override
+	public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+			throws IOException, ServletException {
+		chain.doFilter(new ValidatingHttpRequest( (HttpServletRequest)request ), response);
+	}
+
+	@Override
+	public void init(FilterConfig arg0) throws ServletException {
+		// TODO Auto-generated method stub
+		
+	}
+		}

--- a/inproctester-jersey-tests/src/main/webapp/WEB-INF/web.xml
+++ b/inproctester-jersey-tests/src/main/webapp/WEB-INF/web.xml
@@ -1,32 +1,41 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<web-app xmlns="http://java.sun.com/xml/ns/javaee"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee
+<web-app xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://java.sun.com/xml/ns/javaee
 		  http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
-         version="2.5">
+	version="2.5">
 
-    <servlet>
-        <servlet-name>Jersey Servlet</servlet-name>
-        <servlet-class>com.sun.jersey.spi.container.servlet.ServletContainer</servlet-class>
-        <init-param>
-            <param-name>com.sun.jersey.config.feature.Redirect</param-name>
-            <param-value>true</param-value>
-        </init-param>
-        <init-param>
-            <param-name>com.sun.jersey.config.property.packages</param-name>
-            <param-value>com.thoughtworks.inproctester.jersey.testapp</param-value>
-        </init-param>
-        <init-param>
-            <param-name>com.sun.jersey.api.json.POJOMappingFeature</param-name>
-            <param-value>true</param-value>
-        </init-param>
-        <init-param>
-            <param-name>com.sun.jersey.config.property.WebPageContentRegex</param-name>
-            <param-value>/(images|css|jsp)/.*</param-value>
-        </init-param>
-    </servlet>
-    <servlet-mapping>
-        <servlet-name>Jersey Servlet</servlet-name>
-        <url-pattern>/*</url-pattern>
-    </servlet-mapping>
+	<servlet>
+		<servlet-name>Jersey Servlet</servlet-name>
+		<servlet-class>com.sun.jersey.spi.container.servlet.ServletContainer</servlet-class>
+		<init-param>
+			<param-name>com.sun.jersey.config.feature.Redirect</param-name>
+			<param-value>true</param-value>
+		</init-param>
+		<init-param>
+			<param-name>com.sun.jersey.config.property.packages</param-name>
+			<param-value>com.thoughtworks.inproctester.jersey.testapp</param-value>
+		</init-param>
+		<init-param>
+			<param-name>com.sun.jersey.api.json.POJOMappingFeature</param-name>
+			<param-value>true</param-value>
+		</init-param>
+		<init-param>
+			<param-name>com.sun.jersey.config.property.WebPageContentRegex</param-name>
+			<param-value>/(images|css|jsp)/.*</param-value>
+		</init-param>
+	</servlet>
+	<servlet-mapping>
+		<servlet-name>Jersey Servlet</servlet-name>
+		<url-pattern>/*</url-pattern>
+	</servlet-mapping>
+	<filter>
+		<filter-name>ValidationFilter</filter-name>
+		<filter-class>com.thoughtworks.inproctester.jersey.testapp.validation.ValidationFilter</filter-class>
+	</filter>
+
+	<filter-mapping>
+		<filter-name>ValidationFilter</filter-name>
+		<url-pattern>/*</url-pattern>
+	</filter-mapping>
+
 </web-app>

--- a/inproctester-jersey/src/main/java/com/thoughtworks/inproctester/jersey/InPocessClientHandler.java
+++ b/inproctester-jersey/src/main/java/com/thoughtworks/inproctester/jersey/InPocessClientHandler.java
@@ -120,6 +120,7 @@ public class InPocessClientHandler extends TerminatingClientHandler {
                 InPocessClientHandler.this.writeRequestEntity(ro, new RequestWriter.RequestEntityWriterListener() {
 
                     public void onRequestEntitySize(long size) throws IOException {
+                    	// Not yet implemented
                     }
 
                     public OutputStream onGetOutputStream() throws IOException {

--- a/inproctester-jersey/src/main/java/com/thoughtworks/inproctester/jersey/InProcessTestContainerFactory.java
+++ b/inproctester-jersey/src/main/java/com/thoughtworks/inproctester/jersey/InProcessTestContainerFactory.java
@@ -20,6 +20,7 @@ import com.sun.jersey.test.framework.AppDescriptor;
 import com.sun.jersey.test.framework.WebAppDescriptor;
 import com.sun.jersey.test.framework.spi.container.TestContainer;
 import com.sun.jersey.test.framework.spi.container.TestContainerFactory;
+import com.thoughtworks.inproctester.jersey.exceptions.WebServerEventException;
 import com.thoughtworks.inproctester.jetty.HttpAppTester;
 
 import javax.servlet.Servlet;
@@ -28,6 +29,7 @@ import java.net.URI;
 import java.util.EventListener;
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 public class InProcessTestContainerFactory implements TestContainerFactory {
@@ -74,7 +76,7 @@ public class InProcessTestContainerFactory implements TestContainerFactory {
                     .path(ad.getContextPath())
                     .build();
 
-            LOGGER.info("Creating Inprocess Web Container configured at the base URI " + this.baseUri);
+            LOGGER.log(Level.INFO, "Creating Inprocess Web Container configured at the base URI {}", this.baseUri);
             this.contextPath = getContextPath(ad);
             this.servletPath = getServletPath(ad);
 
@@ -91,21 +93,21 @@ public class InProcessTestContainerFactory implements TestContainerFactory {
         }
 
         private String getContextPath(WebAppDescriptor ad) {
-            String contextPath = ad.getContextPath() == null ? "/" : ad.getContextPath();
-            if (!contextPath.startsWith("/")) {
-                return ("/" + contextPath);
+            String descriptorContextPath = ad.getContextPath() == null ? "/" : ad.getContextPath();
+            if (!descriptorContextPath.startsWith("/")) {
+                return ("/" + descriptorContextPath);
             } else {
-                return contextPath;
+                return descriptorContextPath;
             }
 
         }
 
         private String getServletPath(WebAppDescriptor ad) {
-            String servletPath = ad.getServletPath() == null ? "/" : ad.getServletPath();
-            if (!servletPath.startsWith("/")) {
-                return ("/" + servletPath);
+            String descriptorServletPath = ad.getServletPath() == null ? "/" : ad.getServletPath();
+            if (!descriptorServletPath.startsWith("/")) {
+                return ("/" + descriptorServletPath);
             } else {
-                return servletPath;
+                return descriptorServletPath;
             }
 
         }
@@ -147,7 +149,7 @@ public class InProcessTestContainerFactory implements TestContainerFactory {
                     try {
                         httpServer.addEventListener(eventListener.newInstance());
                     } catch (InstantiationException | IllegalAccessException e) {
-                        throw new RuntimeException(e);
+                        throw new WebServerEventException(e);
                     }
                 }
             }

--- a/inproctester-jersey/src/main/java/com/thoughtworks/inproctester/jersey/InProcessTestContainerFactory.java
+++ b/inproctester-jersey/src/main/java/com/thoughtworks/inproctester/jersey/InProcessTestContainerFactory.java
@@ -76,7 +76,7 @@ public class InProcessTestContainerFactory implements TestContainerFactory {
                     .path(ad.getContextPath())
                     .build();
 
-            LOGGER.log(Level.INFO, "Creating Inprocess Web Container configured at the base URI {}", this.baseUri);
+            LOGGER.log(Level.INFO, "Creating Inprocess Web Container configured at the base URI {0}", this.baseUri);
             this.contextPath = getContextPath(ad);
             this.servletPath = getServletPath(ad);
 

--- a/inproctester-jersey/src/main/java/com/thoughtworks/inproctester/jersey/exceptions/WebServerEventException.java
+++ b/inproctester-jersey/src/main/java/com/thoughtworks/inproctester/jersey/exceptions/WebServerEventException.java
@@ -1,0 +1,10 @@
+package com.thoughtworks.inproctester.jersey.exceptions;
+
+public class WebServerEventException extends RuntimeException {
+	
+	private static final long serialVersionUID = -6999259613578549965L;
+
+	public WebServerEventException(Exception e) {
+		super(e);
+	}
+}

--- a/inproctester-jetty/src/main/java/com/thoughtworks/inproctester/jetty/HttpAppTester.java
+++ b/inproctester-jetty/src/main/java/com/thoughtworks/inproctester/jetty/HttpAppTester.java
@@ -17,6 +17,9 @@ package com.thoughtworks.inproctester.jetty;
 import com.thoughtworks.inproctester.core.InProcConnection;
 import com.thoughtworks.inproctester.core.InProcRequest;
 import com.thoughtworks.inproctester.core.InProcResponse;
+import com.thoughtworks.inproctester.jetty.exceptions.HttpAppStartException;
+import com.thoughtworks.inproctester.jetty.exceptions.HttpAppStopException;
+
 import org.eclipse.jetty.server.HttpConnectionFactory;
 import org.eclipse.jetty.server.LocalConnector;
 import org.eclipse.jetty.server.Server;
@@ -32,6 +35,7 @@ import javax.servlet.Servlet;
 import java.util.EnumSet;
 import java.util.EventListener;
 import java.util.Map;
+import java.util.Set;
 
 public class HttpAppTester implements InProcConnection {
 
@@ -96,13 +100,13 @@ public class HttpAppTester implements InProcConnection {
     }
 
 
-    public void addFilter(Class<? extends Filter> filterClass, String pathSpec, EnumSet<DispatcherType> dispatches, Map<String, String> initParameters) {
-        FilterHolder servletHolder = context.addFilter(filterClass, pathSpec, dispatches);
+    public void addFilter(Class<? extends Filter> filterClass, String pathSpec, Set<DispatcherType> dispatches, Map<String, String> initParameters) {
+        FilterHolder servletHolder = context.addFilter(filterClass, pathSpec, EnumSet.copyOf( dispatches));
         servletHolder.setInitParameters(initParameters);
     }
 
-    public void addFilter(Class<? extends Filter> filterClass, String pathSpec, EnumSet<DispatcherType> dispatches) {
-        context.addFilter(filterClass, pathSpec, dispatches);
+    public void addFilter(Class<? extends Filter> filterClass, String pathSpec, Set<DispatcherType> dispatches) {
+        context.addFilter(filterClass, pathSpec, EnumSet.copyOf(dispatches));
     }
 
     public void addEventListener(EventListener listener) {
@@ -123,7 +127,7 @@ public class HttpAppTester implements InProcConnection {
         } catch (RuntimeException e) {
             throw e;
         } catch (Exception e) {
-            throw new RuntimeException(e);
+            throw new HttpAppStartException(e);
         }
     }
 
@@ -133,7 +137,7 @@ public class HttpAppTester implements InProcConnection {
         } catch (RuntimeException e) {
             throw e;
         } catch (Exception e) {
-            throw new RuntimeException(e);
+            throw new HttpAppStopException(e);
         }
     }
 

--- a/inproctester-jetty/src/main/java/com/thoughtworks/inproctester/jetty/LocalConnection.java
+++ b/inproctester-jetty/src/main/java/com/thoughtworks/inproctester/jetty/LocalConnection.java
@@ -17,6 +17,8 @@ package com.thoughtworks.inproctester.jetty;
 import com.thoughtworks.inproctester.core.InProcRequest;
 import com.thoughtworks.inproctester.core.InProcResponse;
 import com.thoughtworks.inproctester.core.UrlHelper;
+import com.thoughtworks.inproctester.jetty.exceptions.LocalConnectionResponseException;
+
 import org.eclipse.jetty.server.LocalConnector;
 import org.eclipse.jetty.http.HttpTester;
 
@@ -37,7 +39,7 @@ public class LocalConnection  {
         } catch (RuntimeException e) {
             throw e;
         } catch (Exception e) {
-            throw new RuntimeException(e);
+            throw new LocalConnectionResponseException(e);
         }
     }
 

--- a/inproctester-jetty/src/main/java/com/thoughtworks/inproctester/jetty/exceptions/HttpAppStartException.java
+++ b/inproctester-jetty/src/main/java/com/thoughtworks/inproctester/jetty/exceptions/HttpAppStartException.java
@@ -1,0 +1,11 @@
+package com.thoughtworks.inproctester.jetty.exceptions;
+
+public class HttpAppStartException extends RuntimeException {
+
+	private static final long serialVersionUID = 844677459825042151L;
+	
+	public HttpAppStartException(Exception e) {
+		super(e);
+	}
+
+}

--- a/inproctester-jetty/src/main/java/com/thoughtworks/inproctester/jetty/exceptions/HttpAppStopException.java
+++ b/inproctester-jetty/src/main/java/com/thoughtworks/inproctester/jetty/exceptions/HttpAppStopException.java
@@ -1,0 +1,11 @@
+package com.thoughtworks.inproctester.jetty.exceptions;
+
+public class HttpAppStopException extends RuntimeException {
+
+	private static final long serialVersionUID = 3783656435168579286L;
+	
+	public HttpAppStopException(Exception e) {
+		super(e);
+	}
+
+}

--- a/inproctester-jetty/src/main/java/com/thoughtworks/inproctester/jetty/exceptions/LocalConnectionResponseException.java
+++ b/inproctester-jetty/src/main/java/com/thoughtworks/inproctester/jetty/exceptions/LocalConnectionResponseException.java
@@ -1,0 +1,11 @@
+package com.thoughtworks.inproctester.jetty.exceptions;
+
+public class LocalConnectionResponseException extends RuntimeException {
+
+	private static final long serialVersionUID = 4113707830431924809L;
+	
+	public LocalConnectionResponseException(Exception e) {
+		super(e);
+	}
+
+}


### PR DESCRIPTION
The CookieParser date format seems to be working only for a certain default Locale. So the CookieParserTest fails when the default Locale is different. I fixed it by define the date format Locale to US. 

Regarding code quality rules validations, I fixed a few sonar squid from the core and htmlunit modules
- Usage of the generic **RuntimeException**
- Default public constructor on Utilities classes
- Unused imports

I also made a basic set up for log4j2 to be used in place of System.out and for more advanced logging features